### PR TITLE
Fixing null reference error on empty (no parameters) controller method.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/bin/Debug/netcoreapp2.0/Protacon.NetCore.WebApi.ApiKeyAuth.Tests.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/Protacon.NetCore.WebApi.ApiKeyAuth.Tests",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart",
+            "launchBrowser": {
+                "enabled": true,
+                "args": "${auto-detect-url}",
+                "windows": {
+                    "command": "cmd.exe",
+                    "args": "/C start ${auto-detect-url}"
+                },
+                "osx": {
+                    "command": "open"
+                },
+                "linux": {
+                    "command": "xdg-open"
+                }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/Protacon.NetCore.WebApi.ApiKeyAuth.Tests.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/ApiKeyTests.cs
+++ b/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/ApiKeyTests.cs
@@ -1,0 +1,17 @@
+using System.Net;
+using Protacon.NetCore.WebApi.TestUtil;
+using Xunit;
+
+namespace Protacon.NetCore.WebApi.ApiKeyAuth.Tests
+{
+
+    public class ApiKeyTests
+    {
+        [Fact]
+        public void WhenEmptyControllerMethodIsUsed_ThenSwaggerGeneratorWorkAsExpected()
+        {
+            TestHost.Run<TestStartup>().Get("/swagger/v1/swagger.json")
+                .ExpectStatusCode(HttpStatusCode.OK);
+        }
+    }
+}

--- a/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/Program.cs
+++ b/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/Program.cs
@@ -1,0 +1,9 @@
+namespace Protacon.NetCore.WebApi.ApiKeyAuth.Tests
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/Protacon.NetCore.WebApi.ApiKeyAuth.Tests.csproj
+++ b/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/Protacon.NetCore.WebApi.ApiKeyAuth.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Protacon.NetCore.WebApi.TestUtil" Version="2.2.1" />
+    <ProjectReference Include="../Protacon.NetCore.WebApi.ApiKeyAuth/Protacon.NetCore.WebApi.ApiKeyAuth.csproj" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="microsoft.testplatform.testhost" Version="15.5.0" />
+  </ItemGroup>
+</Project>

--- a/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/TestController.cs
+++ b/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/TestController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Protacon.NetCore.WebApi.ApiKeyAuth.Tests
+{
+    [Authorize(AuthenticationSchemes = "ApiKey")]
+    public class TestController: Controller
+    {
+        [HttpGet("/v1/emptyget/")]
+        [ProducesResponseType(typeof(object[]), 200)]
+        public IActionResult EmptyGet()
+        {
+            return Ok(new object[] {});
+        }
+    }
+}

--- a/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/TestStartup.cs
+++ b/Protacon.NetCore.WebApi.ApiKeyAuth.Tests/TestStartup.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.PlatformAbstractions;
+using Swashbuckle.AspNetCore.Swagger;
+
+namespace Protacon.NetCore.WebApi.ApiKeyAuth.Tests
+{
+    public class TestStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services
+                .AddAuthentication()
+                .AddApiKeyAuth(options =>
+                {
+                    options.Keys = new[] {"apiKeyForTests"};
+                });
+
+            services.AddSwaggerGen(c =>
+            {
+                var basePath = PlatformServices.Default.Application.ApplicationBasePath;
+
+                c.SwaggerDoc("v1",
+                    new Info
+                    {
+                        Title = "TestApi",
+                        Version = "v1",
+                        Description = ""
+                    });
+                c.OperationFilter<ApplyApiKeySecurityToDocument>();
+            });
+
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.UseAuthentication();
+            app.UseSwagger();
+            app.UseMvc();
+        }
+    }
+}

--- a/Protacon.NetCore.WebApi.ApiKeyAuth.sln
+++ b/Protacon.NetCore.WebApi.ApiKeyAuth.sln
@@ -1,20 +1,38 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Protacon.NetCore.WebApi.ApiKeyAuth", "Protacon.NetCore.WebApi.ApiKeyAuth\Protacon.NetCore.WebApi.ApiKeyAuth.csproj", "{431C964E-96F1-4D67-B3D4-865C782A4418}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Protacon.NetCore.WebApi.ApiKeyAuth.Tests", "Protacon.NetCore.WebApi.ApiKeyAuth.Tests\Protacon.NetCore.WebApi.ApiKeyAuth.Tests.csproj", "{3527FBCD-68D9-40F5-B933-783B58907E2C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{431C964E-96F1-4D67-B3D4-865C782A4418}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{431C964E-96F1-4D67-B3D4-865C782A4418}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{431C964E-96F1-4D67-B3D4-865C782A4418}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{431C964E-96F1-4D67-B3D4-865C782A4418}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Debug|x64.ActiveCfg = Debug|x64
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Debug|x64.Build.0 = Debug|x64
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Debug|x86.ActiveCfg = Debug|x86
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Debug|x86.Build.0 = Debug|x86
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Release|x64.ActiveCfg = Release|x64
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Release|x64.Build.0 = Release|x64
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Release|x86.ActiveCfg = Release|x86
+		{3527FBCD-68D9-40F5-B933-783B58907E2C}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Protacon.NetCore.WebApi.ApiKeyAuth/ApplyApiKeySecurityToDocument.cs
+++ b/Protacon.NetCore.WebApi.ApiKeyAuth/ApplyApiKeySecurityToDocument.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -18,6 +19,11 @@ namespace Protacon.NetCore.WebApi.ApiKeyAuth
 
             if (apikeyRequired)
             {
+                if (operation.Parameters == null)
+                {
+                    operation.Parameters = new List<IParameter>();
+                }
+
                 operation.Parameters.Add(new NonBodyParameter
                 {
                     Name = "Authorization",

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,15 @@
         .AddAuthentication()
         .AddApiKeyAuth(options =>
         {
-            options.Keys = new List<string>{"test"};
+            if(!Configuration.GetChildren().Any(x => x.Key == "ApiAuthentication"))
+                throw new InvalidOperationException($"Expected 'ApiAuthentication' section.");
+
+            var keys = Configuration.GetSection("ApiAuthentication:Keys")
+                .AsEnumerable()
+                .Where(x => x.Value != null)
+                .Select(x => x.Value);
+
+            options.Keys = keys;
         });
 
     // Configuration (this comes from net core 2.x+, not from this library.)


### PR DESCRIPTION
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Protacon.NetCore.WebApi.ApiKeyAuth.ApplyApiKeySecurityToDocument.Apply(Operation operation, OperationFilterContext context)
   at Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.CreateOperation(ApiDescription apiDescription, ISchemaRegistry schemaRegistry)
   at Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.CreatePathItem(IEnumerable`1 apiDescriptions, ISchemaRegistry schemaRegistry)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GetSwagger(String documentName, String host, String basePath, String[] schemes)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.<Invoke>d__6.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.AspNetCore.Builder.RouterMiddleware.<Invoke>d__4.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.<Invoke>d__6.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.AspNetCore.Hosting.Internal.RequestServicesContainerMiddleware.<Invoke>d__3.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Frame`1.<ProcessRequestsAsync>d__2.MoveNext()
```