### PR TITLE
Fix/ Occurances of "ApiKey" in key itself should not be replaced

### DIFF
--- a/Protacon.NetCore.WebApi.ApiKeyAuth/ApiKeyAuthenticationHandler.cs
+++ b/Protacon.NetCore.WebApi.ApiKeyAuth/ApiKeyAuthenticationHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
@@ -31,7 +32,7 @@ namespace Protacon.NetCore.WebApi.ApiKeyAuth
             if (apiKey == null || !apiKey.Any())
                 return Task.FromResult(AuthenticateResult.Fail("Invalid key format, expected 'ApiKey key'"));
 
-            var parsedKey = apiKey.Replace("ApiKey", "").Trim();
+            var parsedKey = Regex.Replace(apiKey, "^ApiKey", "").Trim();
             var match = Options.ValidApiKeys.SingleOrDefault(x => x == parsedKey);
 
             _logger.LogDebug($"Trying to match apikey '{parsedKey}' against keys '{string.Join(",", Options.ValidApiKeys)}'");


### PR DESCRIPTION
### Problem
Current implementation of parsing the API key replaces not only the "ApiKey" in the beginning of header value but also all occurances of string "ApiKey" in the key itself.

For example if value is "ApiKey IntegratorApiKey:qwerty12345" this would wrongly be parsed as "Integrator:qwerty12345" instead of "IntegratorApiKey:qwerty12345" causing a potentially valid API key to be interpreted as invalid.

### Solution
The solution here is to use Regex to target replace only at the start of the given string value (with ^).
